### PR TITLE
Add cwd to commands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -4,35 +4,6 @@ var statSync = require('fs').statSync; // eslint-disable-line no-sync
 var defaultConfig = require('./default-config');
 var noop = require('./noop');
 
-function startCommand(command, args, logger, callback) {
-  var errors = '';
-  var childProcess = spawn(command, args);
-
-  childProcess.stdout.setEncoding('utf8');
-
-  childProcess.stdout.on('data', function(data) {
-    logger.info(data);
-  });
-
-  childProcess.stderr.on('data', function(data) {
-    errors += data;
-  });
-
-  childProcess.on('error', function(err) {
-    throw err;
-  });
-
-  childProcess.on('close', function() {
-    if (errors) {
-      logger.error(errors);
-      return callback(errors);
-    }
-
-    logger.silly('Theme Kit command finished');
-    return callback();
-  });
-}
-
 module.exports = function command(opts, cb) {
   if (typeof opts === 'function') {
     cb = opts;
@@ -51,6 +22,10 @@ module.exports = function command(opts, cb) {
     opts.args = [];
   }
 
+  if (!opts.cwd) {
+    opts.cwd = process.cwd();
+  }
+
   var logger = require('./logger')(opts.logLevel);
 
   var installPath = join(defaultConfig.destination, defaultConfig.binName);
@@ -59,5 +34,32 @@ module.exports = function command(opts, cb) {
 
   statSync(installPath);
 
-  return startCommand(installPath, opts.args, logger, cb);
+  var errors = '';
+  var childProcess = spawn(installPath, opts.args, {
+    cwd: opts.cwd
+  });
+
+  childProcess.stdout.setEncoding('utf8');
+
+  childProcess.stdout.on('data', function(data) {
+    logger.info(data);
+  });
+
+  childProcess.stderr.on('data', function(data) {
+    errors += data;
+  });
+
+  childProcess.on('error', function(err) {
+    throw err;
+  });
+
+  childProcess.on('close', function() {
+    if (errors) {
+      logger.error(errors);
+      return cb(errors);
+    }
+
+    logger.silly('Theme Kit command finished');
+    return cb();
+  });
 };


### PR DESCRIPTION
@Shopify/themes-fed @mikkoh 

Added in an option to set `cwd` when running command; relevant to slate-cli.

Also, removed that `startCommand` function. Not really necessary, command only runs commands.