### PR TITLE
Simplified STDIO

### DIFF
--- a/__tests__/postinstall.js
+++ b/__tests__/postinstall.js
@@ -1,8 +1,0 @@
-const themekit = require('../lib/themekit');
-const {version} = require('../lib/config');
-
-test('successfully runs binary', async () => {
-  global.process.stdout.write = jest.fn();
-  await themekit.command('version');
-  expect(global.process.stdout.write).toHaveBeenLastCalledWith(expect.stringContaining(version));
-});

--- a/__tests__/run-executable.js
+++ b/__tests__/run-executable.js
@@ -15,6 +15,6 @@ describe('runExecutable', () => {
 
     await runExecutable(args, cwd);
 
-    expect(spawn).toBeCalledWith(pathToExecutable, args, {cwd});
+    expect(spawn).toBeCalledWith(pathToExecutable, args, {cwd, stdio: 'inherit'});
   });
 });

--- a/lib/run-executable.js
+++ b/lib/run-executable.js
@@ -14,31 +14,17 @@ function runExecutable(args, cwd, logLevel) {
   const logger = require('./logger')(logLevel);
   return new Promise((resolve, reject) => {
     logger.silly('Theme Kit command starting');
-    let errors = '';
 
     const pathToExecutable = path.join(config.destination, config.binName);
     fs.statSync(pathToExecutable);
 
-    const childProcess = spawn(pathToExecutable, args, {cwd});
-
-    childProcess.stdout.setEncoding('utf8');
-    childProcess.stdout.on('data', (data) => {
-      process.stdout.write(data.toString());
-    });
-
-    childProcess.stderr.on('data', (data) => {
-      errors += data;
-    });
+    const childProcess = spawn(pathToExecutable, args, {cwd, stdio: 'inherit'});
 
     childProcess.on('error', (err) => {
-      throw err;
+      reject(err);
     });
 
     childProcess.on('close', () => {
-      if (errors) {
-        reject(errors);
-      }
-
       logger.silly('Theme Kit command finished');
       resolve();
     });


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
This PR fixes #25 among other things, simply by replacing the custom logging (hooked to the child process' `stdout`) with the `stdio: inherit` option flag in `child_process.spawn`.

From the Node.js docs ([link](https://nodejs.org/api/child_process.html#child_process_options_stdio)):
>'inherit' - Pass through the corresponding stdio stream to/from the parent process

This is beneficial for a few reasons:
* Output is formatted the same as Theme Kit's (more consistent = better?)
* ANSI colours aren't lost when piping child process output
* Fewer lines of code to maintain and test
* More faithful to the Node.js API's intended purpose

### Some Notes

* ~This PR **shouldn't be merged in until Theme Kit `0.8.1` gets released** and integrated into this package because of an issue with error logging introduced in the `0.8.0` Theme Kit binary. See Shopify/themekit#562.~ Theme Kit 0.8.1 has been released!

* I removed a unit test that spied on the now-removed custom logging entirely. It was kind of a bad unit test anyways (relied on testing the binary's output), so I'll be opening a separate PR that properly tests the contents of `install.js`. (See #28)

### Checklist
For contributors:
- [x] I have updated the documentation in the [README file](https://github.com/Shopify/node-themekit/blob/master/README.md) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

Considerations:
- Changes may require updates to the [Slate docs](https://shopify.github.io/slate/) or the [`@shopify/slate-tools`](https://github.com/Shopify/slate/tree/master/packages/slate-tools) package.
