### PR TITLE
Forgot to include noIgnore as kebab case

### DIFF
--- a/__tests__/themekit.js
+++ b/__tests__/themekit.js
@@ -69,6 +69,21 @@ describe('themekit', () => {
     );
   });
 
+  test('deploy ignore files', async () => {
+    await themekit.command('deploy', {
+      noIgnore: true
+    });
+
+    expect(spawn).toBeCalledWith(
+      pathToExecutable,
+      ['deploy', '--no-ignore', '--no-update-notifier'],
+      {
+        cwd,
+        stdio: ['inherit', 'inherit', 'pipe']
+      }
+    );
+  });
+
   test('deploy ignore files and ignore file', async () => {
     await themekit.command('deploy', {
       ignoredFiles: ['templates/404.liquid', 'templates/article.liquid'],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,6 +28,8 @@ function getFlagArrayFromObject(obj) {
     const flag = `--${key.toLowerCase()}`;
     if (key === 'noUpdateNotifier' && typeof obj[key] === 'boolean') {
       return obj[key] ? [...arr, '--no-update-notifier'] : arr;
+    } else if (key === 'noIgnore' && typeof obj[key] === 'boolean') {
+      return obj[key] ? [...arr, '--no-ignore'] : arr;
     } else if (typeof obj[key] === 'boolean') {
       return obj[key] ? [...arr, flag] : arr;
     } else if (key === 'ignoredFile') {


### PR DESCRIPTION
Didn't initially realize noIgnore was still kebab case, it's not documented in themekit, but it's still a flag (https://github.com/Shopify/themekit/blob/master/cmd/theme.go) , change should allow it to still work. 

