### PR TITLE
Update themekit binary to 1.0.3

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   baseURL: 'https://shopify-themekit.s3.amazonaws.com',
-  version: '1.0.1',
+  version: '1.0.3',
   destination: path.join(__dirname, '..', 'bin'),
   binName: process.platform === 'win32' ? 'theme.exe' : 'theme'
 };


### PR DESCRIPTION
Updates embedded [themekit](https://github.com/Shopify/themekit/releases/tag/v1.0.3) binary to 1.0.3

This update includes deployment with new pages section such as `pages/customers` for upcoming new Sections schema.

Same as https://github.com/Shopify/node-themekit/pull/43 and https://github.com/Shopify/node-themekit/pull/43