### PR TITLE
Remove mentions of Slate from GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,9 +2,6 @@
 
 *Succinct outline of the problem or request.*
 
-*If the issue involves the node packages [@shopify/slate-tools](https://github.com/Shopify/slate-tools) or
-[@shopify/slate](https://github.com/Shopify/slate-cli), please specify.*
-
 ### Replication steps
 
 *How to replicate the problem. Screenshots or video?*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,3 @@ For contributors:
 For maintainers:
 - [ ] I have :tophat:'d these changes.
 - [ ] I have bumped the `package.json` version in a separate PR, if applicable.
-
-Considerations:
-- Changes may require updates to the [Slate docs](https://shopify.github.io/slate/) or the [`@shopify/slate-tools`](https://github.com/Shopify/slate/tree/master/packages/slate-tools) package.


### PR DESCRIPTION
Since Slate is [no longer supported](https://shopify.github.io/slate/docs/about), can we remove the mentions of it from the PR and Issue templates?