### PR TITLE
Bump Themekit version to 1.2.0

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   baseURL: 'https://shopify-themekit.s3.amazonaws.com',
-  version: '1.1.4',
+  version: '1.2.0',
   destination: path.join(__dirname, '..', 'bin'),
   binName: process.platform === 'win32' ? 'theme.exe' : 'theme'
 };


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Bumping themekit version to 1.2.0

Verified that themekit version was updated by running `node ./lib/cli.js install` and checked the version
```
node-themekit % bin/theme version
ThemeKit 1.2.0 darwin/amd64
```


### Checklist
For contributors:
- [ ] I have updated the documentation in the [README file](https://github.com/Shopify/node-themekit/blob/master/README.md) to reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.
- [x] I have bumped the `package.json` version in a separate PR, if applicable.
